### PR TITLE
Fix restore incorrect keys when inserting into Postgres

### DIFF
--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -1600,14 +1600,14 @@ controller::get_validation_mode() const {
     return my->conf.block_validation_mode;
 }
 
+const chain_id_type&
+controller::get_chain_id() const {
+    return my->chain_id;
+}
+
 const genesis_state&
 controller::get_genesis_state() const {
     return my->conf.genesis;
-}
-
-chain_id_type
-controller::get_chain_id() const {
-    return my->chain_id;
 }
 
 const abi_serializer&

--- a/libraries/chain/include/evt/chain/controller.hpp
+++ b/libraries/chain/include/evt/chain/controller.hpp
@@ -196,11 +196,10 @@ public:
     bool charge_free_mode() const;
     bool contracts_console() const;
 
-    chain_id_type get_chain_id() const;
-
     db_read_mode    get_read_mode() const;
     validation_mode get_validation_mode() const;
 
+    const chain_id_type& get_chain_id() const;
     const genesis_state& get_genesis_state() const;
 
     signal<void(const signed_block_ptr&)>         pre_accepted_block;

--- a/plugins/postgres_plugin/evt_pg.cpp
+++ b/plugins/postgres_plugin/evt_pg.cpp
@@ -287,7 +287,8 @@ format_array_to(fmt::memory_buffer& buf, Iterator begin, Iterator end) {
     if(begin != end) {
         auto it = begin;
         for(; it != end - 1; it++) {
-            fmt::format_to(buf, fmt("\"{}\","), (std::string)*it);
+            auto str = (std::string)*it;
+            fmt::format_to(buf, fmt("\"{}\","), str);
         }
         fmt::format_to(buf, fmt("\"{}\""), (std::string)*it);
     }

--- a/plugins/postgres_plugin/include/evt/postgres_plugin/evt_pg.hpp
+++ b/plugins/postgres_plugin/include/evt/postgres_plugin/evt_pg.hpp
@@ -43,6 +43,7 @@ using ft_holders_t = chain::small_vector_base<chain::ft_holder>;
 
 struct copy_context;
 struct trx_context;
+
 struct add_context : boost::noncopyable {
 public:
     add_context(copy_context& cctx, const chain_id_t& chain_id, const abi_t& abi, const exec_ctx_t& exec_ctx)


### PR DESCRIPTION
fixes #122 
`chain_id` returned by `get_chain_id` is escaped from temporary variable.